### PR TITLE
Experimental macos support. Closes #5

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,64 @@
+name: Build macOS Universal Binary
+
+on:
+  push:
+    branches:
+      - 'master'
+  release:
+    types: [published]  # Trigger on published release
+
+jobs:
+  build-universal-macos:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        run: |
+          brew update
+          brew install cmake ninja
+
+      - name: Configure Build for x86_64
+        run: |
+          mkdir -p build_x86_64
+          cd build_x86_64
+          cmake .. -DCMAKE_BUILD_TYPE=Release -G "Ninja" \
+                   -DCMAKE_OSX_ARCHITECTURES="x86_64"
+
+      - name: Build Project for x86_64
+        run: |
+          cd build_x86_64
+          cmake --build .
+
+      - name: Configure Build for arm64
+        run: |
+          mkdir -p build_arm64
+          cd build_arm64
+          cmake .. -DCMAKE_BUILD_TYPE=Release -G "Ninja" \
+                   -DCMAKE_OSX_ARCHITECTURES="arm64"
+
+      - name: Build Project for arm64
+        run: |
+          cd build_arm64
+          cmake --build .
+
+      - name: Combine the binaries into a universal binary
+        run: |
+          mkdir -p artifacts
+          lipo -create -output artifacts/sfo-macos-universal \
+            build_x86_64/bin/sfo \
+            build_arm64/bin/sfo
+
+      - name: Verify Universal Binary
+        run: |
+          file artifacts/sfo-macos-universal
+
+      - name: Upload Release Artifact
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/sfo-macos-universal
+          name: sfo-macos-universal
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+artifacts/
+build_*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(sfo
+    DESCRIPTION "PARAM.SFO Manager for PS4"
+    HOMEPAGE_URL https://github.com/hippe68/sfo
+    VERSION 1.03
+    LANGUAGES C
+)
+
+add_executable(${PROJECT_NAME} sfo.c)
+
+set_target_properties(${PROJECT_NAME}
+    PROPERTIES
+    C_STANDARD 17
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+
+install(TARGETS sfo RUNTIME DESTINATION bin)


### PR DESCRIPTION
Adds a github action workflow that triggers a macOS universal binary build when a release is published. Uses the free macos-latest runner. Closes #5 